### PR TITLE
Update dev_scripts.sql

### DIFF
--- a/dev_scripts.sql
+++ b/dev_scripts.sql
@@ -9,3 +9,9 @@ CREATE TABLE test_table (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- Timestamp of row creation
     is_active BOOLEAN DEFAULT TRUE  -- Example boolean field
 );
+
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- 2024-05-07: Remove `UPDATED_AT` column from QUICK_SEARCH_QUERY_LOGS, per https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/270
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ALTER TABLE PUBLIC.QUICK_SEARCH_QUERY_LOGS
+DROP COLUMN UPDATED_AT;


### PR DESCRIPTION
#### Fixes

* Partially addresses [v2 logging enhancement](https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/270) by meeting requirement to remove `update_at` column in `quick_search_query_logs`

#### Description

* Adds to `dev_scripts` a schema update that will remove the `update_at` column in the `quick_search_query_logs` table 

#### Testing

* No steps required. 

#### Performance

* No performance impact.

#### Docs

* No docs impact