### PR TITLE
Archive info database overhaul

### DIFF
--- a/dev_scripts.sql
+++ b/dev_scripts.sql
@@ -225,13 +225,15 @@ COMMIT;
 -------------------------------
 -- 2024-07-22: https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/309
 -------------------------------
+SET timezone TO 'EST';
+
 -- Create new table for archive info
 CREATE TABLE IF NOT EXISTS public.data_sources_archive_info
 (
     airtable_uid character varying COLLATE pg_catalog."default" NOT NULL,
     update_frequency character varying COLLATE pg_catalog."default",
     last_cached date,
-    next_cache timestamptz,
+    next_cache timestamp,
     CONSTRAINT airtable_uid_pk PRIMARY KEY (airtable_uid),
     CONSTRAINT airtale_uid_fk FOREIGN KEY (airtable_uid)
         REFERENCES public.data_sources (airtable_uid) MATCH SIMPLE


### PR DESCRIPTION
#### Fixes

* Part of https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/309 and https://github.com/Police-Data-Accessibility-Project/automatic-archives/issues/21

#### Description

* Adds a new table called `data_sources_archive_info` that contains `update_frequency`, `last_cached` and a new column called `next_cache`
* Relevant data from `data_sources` is migrated to `data_sources_archive_info` then dropped from the old table
* Adds a trigger that will create a linked row any time a row is inserted into `data_sources`