### PR TITLE
Drop session_tokens table

### DIFF
--- a/dev_scripts.sql
+++ b/dev_scripts.sql
@@ -347,3 +347,7 @@ FROM
     users u
 LEFT JOIN
     external_accounts ea ON u.id = ea.user_id;
+-------------------------------
+-- 2024-08-01: https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/322
+-------------------------------
+DROP Table public.session_tokens


### PR DESCRIPTION
#### Fixes

* Addresses database component of https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/322

#### Description

* Drops `session_tokens` table

#### Testing

* Confirm absence of `session_tokens` table in database after run.

#### Performance

* Not applicable.

#### Docs

* Not applicable.